### PR TITLE
Added a method to load a VRM from memory (data array of uint8) asynchronously

### DIFF
--- a/Source/VRM4ULoader/Private/LoaderBPFunctionLibrary.cpp
+++ b/Source/VRM4ULoader/Private/LoaderBPFunctionLibrary.cpp
@@ -558,6 +558,21 @@ bool ULoaderBPFunctionLibrary::LoadVRMFile(const UVrmAssetListObject *InVrmAsset
 	return LoadVRMFileLocal(InVrmAsset, OutVrmAsset, filepath);
 }
 
+void ULoaderBPFunctionLibrary::LoadVRMFromMemoryAsync(const UObject* WorldContextObject, const class UVrmAssetListObject* InVrmAsset, class UVrmAssetListObject*& OutVrmAsset, const TArray<uint8>& Data, const FImportOptionData& OptionForRuntimeLoad, struct FLatentActionInfo LatentInfo) {
+	VRMConverter::Options::Get().SetVrmOption(&OptionForRuntimeLoad);
+
+	if (UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull))
+	{
+		FLatentActionManager& LatentActionManager = World->GetLatentActionManager();
+		if (LatentActionManager.FindExistingAction<FVrmAsyncLoadAction>(LatentInfo.CallbackTarget, LatentInfo.UUID) == NULL)
+		{
+			FVrmAsyncLoadActionParam p = { InVrmAsset, OutVrmAsset, OptionForRuntimeLoad, FString("a.vrm"), Data.GetData(), (size_t)Data.Num()};
+			LatentActionManager.AddNewAction(LatentInfo.CallbackTarget, LatentInfo.UUID, new FVrmAsyncLoadAction(LatentInfo, p));
+		}
+	}
+	return;
+}
+
 void ULoaderBPFunctionLibrary::LoadVRMFileAsync(const UObject* WorldContextObject, const class UVrmAssetListObject* InVrmAsset, class UVrmAssetListObject*& OutVrmAsset, const FString filepath, const FImportOptionData& OptionForRuntimeLoad, struct FLatentActionInfo LatentInfo) {
 	VRMConverter::Options::Get().SetVrmOption(&OptionForRuntimeLoad);
 

--- a/Source/VRM4ULoader/Private/VrmAsyncLoadAction.cpp
+++ b/Source/VRM4ULoader/Private/VrmAsyncLoadAction.cpp
@@ -199,6 +199,9 @@ void FVrmAsyncLoadAction::UpdateOperation(FLatentResponse& Response)
 
 
 		TFunction< void() > f = [&] {
+			if (param.dataSize > 0) {
+				return;
+			}
 			if (FFileHelper::LoadFileToArray(localAsset.vrmLocalRes, *param.filepath)) {
 				param.pData = localAsset.vrmLocalRes.GetData();
 				param.dataSize = localAsset.vrmLocalRes.Num();
@@ -228,7 +231,7 @@ void FVrmAsyncLoadAction::UpdateOperation(FLatentResponse& Response)
 		++SequenceCount;
 
 		localAsset.Importer = new Assimp::Importer();
-		localAsset.ScenePtr = localAsset.Importer->ReadFileFromMemory(localAsset.vrmLocalRes.GetData(), localAsset.vrmLocalRes.Num(),
+		localAsset.ScenePtr = localAsset.Importer->ReadFileFromMemory(param.pData, param.dataSize,
 			aiProcess_Triangulate | aiProcess_MakeLeftHanded | aiProcess_CalcTangentSpace | aiProcess_GenSmoothNormals | aiProcess_OptimizeMeshes,
 			"vrm");
 		return;

--- a/Source/VRM4ULoader/Public/LoaderBPFunctionLibrary.h
+++ b/Source/VRM4ULoader/Public/LoaderBPFunctionLibrary.h
@@ -88,7 +88,10 @@ public:
 
 	UFUNCTION(BlueprintCallable,Category="VRM4U", meta = (DynamicOutputParam = "OutVrmAsset"))
 	static bool LoadVRMFile(const class UVrmAssetListObject *InVrmAsset, class UVrmAssetListObject *&OutVrmAsset, const FString filepath, const FImportOptionData &OptionForRuntimeLoad);
-
+	
+	UFUNCTION(BlueprintCallable, Category = "VRM4U", meta = (Latent, DynamicOutputParam = "OutVrmAsset", WorldContext = "WorldContextObject", LatentInfo = "LatentInfo"))
+	static void LoadVRMFromMemoryAsync(const UObject* WorldContextObject, const UVrmAssetListObject* InVrmAsset, UVrmAssetListObject*& OutVrmAsset, const TArray<uint8>& Data, const FImportOptionData& OptionForRuntimeLoad, FLatentActionInfo LatentInfo);
+	
 	UFUNCTION(BlueprintCallable, Category = "VRM4U", meta = (Latent, DynamicOutputParam = "OutVrmAsset", WorldContext = "WorldContextObject", LatentInfo = "LatentInfo"))
 	static void LoadVRMFileAsync(const UObject* WorldContextObject, const class UVrmAssetListObject* InVrmAsset, class UVrmAssetListObject*& OutVrmAsset, const FString filepath, const FImportOptionData& OptionForRuntimeLoad, struct FLatentActionInfo LatentInfo);
 


### PR DESCRIPTION
Adds a method to load a VRM from memory (data array of uint8) asynchronously.

私の日本語が下手だったらごめんなさい。 私はGoogle翻訳を使っています"。 この関数メソッドを使用すると、開発者はメモリ (uint8 のデータ配列) から VRM を非同期にロードできます。