### PR TITLE
Bugfix. Insufficient pattern matching can lead to crash.

### DIFF
--- a/Source/VRM4ULoader/Private/VrmJson.cpp
+++ b/Source/VRM4ULoader/Private/VrmJson.cpp
@@ -19,7 +19,7 @@ bool VrmJson::init(const uint8_t* pData, size_t size) {
 
 			for (int i = 0; i < 4; ++i) {
 				if (str[i] != pData[c_start + i]) {
-					continue;
+					break;
 				}
 				bFound = true;
 			}
@@ -74,7 +74,7 @@ bool VRMIsVRM10(const uint8_t* pData, size_t size) {
 
 			for (int i = 0; i < 4; ++i) {
 				if (str[i] != pData[c_start + i]) {
-					continue;
+					break;
 				}
 				bFound = true;
 			}


### PR DESCRIPTION
by using continue the loop does not restart the pattern matching and it can lead to that we get faulty indexes that in turn can lead to crashing. The correct code here is to break in the inner loop so we return to the outer loop.