### PR TITLE
ヘッダー名差異のためフラグ LINUX_BUILD を追加；GNU C++ エラー防止のためループを強化（コピーせず、一項演算子を用いたインプレース編集を実施）

### DIFF
--- a/Source/VRM4U/Private/AnimNode_VrmSpringBone.cpp
+++ b/Source/VRM4U/Private/AnimNode_VrmSpringBone.cpp
@@ -388,8 +388,8 @@ void FAnimNode_VrmSpringBone::ConditionalDebugDraw(FPrimitiveDrawInterface* PDI,
 		TArray<SData> dataList;
 		TArray<int32> boneList;
 
-		for (const auto spr : MetaObjectLocal->VRMSpringMeta) {
-			for (const auto boneName : spr.boneNames) {
+		for (const auto &spr : MetaObjectLocal->VRMSpringMeta) {
+			for (const auto &boneName : spr.boneNames) {
 				int32_t boneIndex = PreviewSkelMeshComp->GetBoneIndex(*boneName);
 				boneList.AddUnique(boneIndex);
 
@@ -405,7 +405,7 @@ void FAnimNode_VrmSpringBone::ConditionalDebugDraw(FPrimitiveDrawInterface* PDI,
 					TArray<int32> c;
 					VRMUtil::GetDirectChildBones(VRMGetRefSkeleton( VRMGetSkinnedAsset(PreviewSkelMeshComp) ), boneList[i], c);
 					if (c.Num()) {
-						for (const auto cc : c) {
+						for (const auto &cc : c) {
 							boneList.AddUnique(cc);
 
 							SData s;

--- a/Source/VRM4U/Private/VrmRuntimeSettings.cpp
+++ b/Source/VRM4U/Private/VrmRuntimeSettings.cpp
@@ -7,7 +7,11 @@
 #include "Misc/MessageDialog.h"
 #include "UnrealEdMisc.h"
 #include "Misc/ConfigCacheIni.h"
+#ifdef LINUX_BUILD
+#include "HAL/PlatformFileManager.h"
+else
 #include "HAL/PlatformFilemanager.h"
+#endif
 #endif
 
 #define LOCTEXT_NAMESPACE "VRM4U"


### PR DESCRIPTION
こんにちは、私は韓国で小さな大学に通う学生です。実は、あなたが公開されたプラグインを私が使用しているUbuntu 24.04のコンピュータで利用しようと試みたのですが、クロスビルド環境におけるヘッダー名の不一致がコンパイルを妨げました。また、GNU C++の場合、大量のループ処理においてイテレータがその要素をコピーして処理することを禁止しています。このような理由から、私はLINUX_BUILDというプリプロセッサを用意し、破壊的でない形でクロスプラットフォームサポートを実現する方向を模索しています。私は専門の開発者ではないため、コードを少しご確認いただく必要はありますが、10年間Linuxを使い続けてきた者として、おそらく私のパッチに問題はないと確信しています。
日本語が話せないため、翻訳を通じてお願いする点をご了承ください。お返事は翻訳サービスを通じて確認いたします。