### PR TITLE
Fix vertex color not being applied to imported meshes

### DIFF
--- a/Source/VRM4ULoader/Private/VrmConvertModel.cpp
+++ b/Source/VRM4ULoader/Private/VrmConvertModel.cpp
@@ -1221,11 +1221,12 @@ bool VRMConverter::ConvertModel(UVrmAssetListObject *vrmAssetList) {
 				TArray<FSoftSkinVertexLocal> meshWeight;
 				auto &mInfo = result.meshInfo[meshID];
 
+#if UE_VERSION_NEWER_THAN_OR_EQUAL(5,0,0)
 				// VertexColor Override Allow
 				if (0 < mInfo.VertexColors.Num() && sk->GetHasVertexColors() == false) {
 					sk->SetHasVertexColors(true);
 				}
-
+#endif
 				for (int i = 0; i < mInfo.Vertices.Num(); ++i) {
 					FSoftSkinVertexLocal *meshS = new(meshWeight) FSoftSkinVertexLocal();
 					*meshS = softSkinVertexLocalZero;

--- a/Source/VRM4ULoader/Private/VrmConvertModel.cpp
+++ b/Source/VRM4ULoader/Private/VrmConvertModel.cpp
@@ -1221,6 +1221,11 @@ bool VRMConverter::ConvertModel(UVrmAssetListObject *vrmAssetList) {
 				TArray<FSoftSkinVertexLocal> meshWeight;
 				auto &mInfo = result.meshInfo[meshID];
 
+				// VertexColor Override Allow
+				if (0 < mInfo.VertexColors.Num() && sk->GetHasVertexColors() == false) {
+					sk->SetHasVertexColors(true);
+				}
+
 				for (int i = 0; i < mInfo.Vertices.Num(); ++i) {
 					FSoftSkinVertexLocal *meshS = new(meshWeight) FSoftSkinVertexLocal();
 					*meshS = softSkinVertexLocalZero;
@@ -1285,7 +1290,8 @@ bool VRMConverter::ConvertModel(UVrmAssetListObject *vrmAssetList) {
 
 					if (i < mInfo.VertexColors.Num()) {
 						auto &c = mInfo.VertexColors[i];
-						meshS->Color = FColor(c.R, c.G, c.B, c.A);
+						//Convert FLinearColor (0.0 - 1.0) to FColor (0 - 255)
+						meshS->Color = c.ToFColor(false);
 					}
 
 					FSoftSkinVertexLocal &s = Weight[currentVertex + i];


### PR DESCRIPTION
- Tested on Unreal Engine 5.7.4 / Unity UniVRM 0.99.1
- Fixed FLinearColor to FColor conversion using ToFColor(false) to prevent value scaling issues
- Added logic to automatically apply SetHasVertexColors(true) on SkeletalMesh if vertex color data exists
